### PR TITLE
clang / BSD sed installation updates (i.e., macOS)

### DIFF
--- a/src/libnnp/makefile
+++ b/src/libnnp/makefile
@@ -97,11 +97,12 @@ headers:
 
 version:
 	@$(eval GIT_REV_SHORT = $(shell git rev-parse --short HEAD))
-	@sed -i -E "s/\(NNP_GIT_REV_SHORT\) .*/\1 \"${GIT_REV_SHORT}\"/" version.h
+	@sed -i.bak -E "s/(NNP_GIT_REV_SHORT) .*/\1 \"${GIT_REV_SHORT}\"/" version.h
 	@$(eval GIT_REV = $(shell git rev-parse HEAD))
-	@sed -i -E "s/\(NNP_GIT_REV\) .*/\1 \"${GIT_REV}\"/" version.h
+	@sed -i.bak -E "s/(NNP_GIT_REV) .*/\1 \"${GIT_REV}\"/" version.h
 	@$(eval GIT_BRANCH = $(shell git rev-parse --abbrev-ref HEAD))
-	@sed -i -E "s/\(NNP_GIT_BRANCH\) .*/\1 \"${GIT_BRANCH}\"/" version.h
+	@sed -i.bak -E "s/(NNP_GIT_BRANCH) .*/\1 \"${GIT_BRANCH}\"/" version.h
+	@rm version.h.bak
 
 ${SLIB}: ${SOBJ}
 	${AR} ${ARFLAGS} $@ $+

--- a/src/libnnp/makefile
+++ b/src/libnnp/makefile
@@ -97,11 +97,11 @@ headers:
 
 version:
 	@$(eval GIT_REV_SHORT = $(shell git rev-parse --short HEAD))
-	@sed -i -r "s/(NNP_GIT_REV_SHORT) .*/\1 \"${GIT_REV_SHORT}\"/" version.h
+	@sed -i -E "s/\(NNP_GIT_REV_SHORT\) .*/\1 \"${GIT_REV_SHORT}\"/" version.h
 	@$(eval GIT_REV = $(shell git rev-parse HEAD))
-	@sed -i -r "s/(NNP_GIT_REV) .*/\1 \"${GIT_REV}\"/" version.h
+	@sed -i -E "s/\(NNP_GIT_REV\) .*/\1 \"${GIT_REV}\"/" version.h
 	@$(eval GIT_BRANCH = $(shell git rev-parse --abbrev-ref HEAD))
-	@sed -i -r "s/(NNP_GIT_BRANCH) .*/\1 \"${GIT_BRANCH}\"/" version.h
+	@sed -i -E "s/\(NNP_GIT_BRANCH\) .*/\1 \"${GIT_BRANCH}\"/" version.h
 
 ${SLIB}: ${SOBJ}
 	${AR} ${ARFLAGS} $@ $+

--- a/src/libnnp/version.h
+++ b/src/libnnp/version.h
@@ -18,8 +18,8 @@
 #define VERSION_H
 
 #define NNP_VERSION "2.0.0"
-#define NNP_GIT_REV "110146d504d5a57262cc02f9a67cca0631ee565a"
-#define NNP_GIT_REV_SHORT "110146d"
-#define NNP_GIT_BRANCH "install_mac"
+#define NNP_GIT_REV "1c49b4491e973f72ff3f1a737bf37378a0b01f2e"
+#define NNP_GIT_REV_SHORT "1c49b44"
+#define NNP_GIT_BRANCH "master"
 
 #endif

--- a/src/libnnp/version.h
+++ b/src/libnnp/version.h
@@ -18,8 +18,8 @@
 #define VERSION_H
 
 #define NNP_VERSION "2.0.0"
-#define NNP_GIT_REV "1c49b4491e973f72ff3f1a737bf37378a0b01f2e"
-#define NNP_GIT_REV_SHORT "1c49b44"
-#define NNP_GIT_BRANCH "master"
+#define NNP_GIT_REV "110146d504d5a57262cc02f9a67cca0631ee565a"
+#define NNP_GIT_REV_SHORT "110146d"
+#define NNP_GIT_BRANCH "install_mac"
 
 #endif

--- a/src/makefile
+++ b/src/makefile
@@ -59,6 +59,7 @@ INSTALL_LIB=${HOME}/local/lib
         clean-doc \
         clean-doc-sphinx \
         clean-doc-doxygen \
+	clean-no-doc \
         clean-libnnp \
         clean-libnnptrain \
         clean-libnnpif \
@@ -150,22 +151,25 @@ static: libnnp-static \
 clean:	clean-doc \
 	clean-doc-sphinx \
 	clean-doc-doxygen \
-	clean-libnnp \
-	clean-libnnptrain \
-	clean-libnnpif \
-	clean-nnp-comp2 \
-	clean-nnp-convert \
-	clean-nnp-cutoff \
-	clean-nnp-dataset \
-	clean-nnp-dist \
-	clean-nnp-norm \
-	clean-nnp-predict \
-	clean-nnp-prune \
-	clean-nnp-scaling \
-	clean-nnp-select \
-	clean-nnp-symfunc \
-	clean-nnp-train \
-	clean-pynnp
+	clean-no-doc
+
+clean-no-doc: clean-libnnp \
+	      clean-libnnptrain \
+	      clean-libnnpif \
+	      clean-nnp-comp2 \
+	      clean-nnp-convert \
+	      clean-nnp-cutoff \
+	      clean-nnp-dataset \
+	      clean-nnp-dist \
+	      clean-nnp-norm \
+	      clean-nnp-predict \
+	      clean-nnp-prune \
+	      clean-nnp-scaling \
+	      clean-nnp-select \
+	      clean-nnp-symfunc \
+	      clean-nnp-train \
+	      clean-pynnp
+
 
 #######
 # doc #

--- a/src/makefile.llvm
+++ b/src/makefile.llvm
@@ -1,0 +1,55 @@
+#!/bin/make -f
+
+###############################################################################
+# EXTERNAL LIBRARY PATHS
+###############################################################################
+# Enter here paths to GSL or EIGEN if they are not in your standard include
+# path. DO NOT completely remove the entry, leave at least "./".
+PROJECT_GSL=/usr/local/include/gsl
+PROJECT_EIGEN=/usr/local/include/eigen3
+
+###############################################################################
+# COMPILERS AND FLAGS
+###############################################################################
+PROJECT_CC=clang++
+PROJECT_MPICC=mpic++
+PROJECT_CFLAGS=-O3 -march=native -std=c++98 -Xpreprocessor -fopenmp -lomp
+PROJECT_CFLAGS_MPI=-Wno-long-long
+PROJECT_DEBUG=-g -pedantic-errors -Wall -Wextra
+PROJECT_AR=ar
+PROJECT_ARFLAGS=-rcsv
+PROJECT_CFLAGS_BLAS=
+PROJECT_LDFLAGS_BLAS=-lblas
+
+PROJECT_OPTIONS=-I${HOME}/miniconda3/envs/n2p2/include/
+
+###############################################################################
+# COMPILE-TIME OPTIONS
+###############################################################################
+
+# Do not use symmetry function groups.
+#PROJECT_OPTIONS+= -DNOSFGROUPS
+
+# Do not use cutoff function cache.
+#PROJECT_OPTIONS+= -DNOCFCACHE
+
+# Build with dummy Stopwatch class.
+#PROJECT_OPTIONS+= -DNOTIME
+
+# Disable check for low number of neighbors.
+#PROJECT_OPTIONS+= -DNONEIGHCHECK
+
+# Compile without MPI support.
+#PROJECT_OPTIONS+= -DNOMPI
+
+# Use BLAS together with Eigen.
+PROJECT_OPTIONS+= -DEIGEN_USE_BLAS
+
+# Disable all C++ asserts (also Eigen debugging).
+#PROJECT_OPTIONS+= -DNDEBUG
+
+# Use Intel MKL together with Eigen.
+#PROJECT_OPTIONS+= -DEIGEN_USE_MKL_ALL
+
+# Disable Eigen multi threading.
+OPTIONS+= -DEIGEN_DONT_PARALLELIZE


### PR DESCRIPTION
This is designed to facilitate installation on macOS. It manages two issues:

1. `sed` incompatibility

While building `libnnp`, `sed` is used to insert the git revision into `version.h`. The existing code was for GNU `sed`; macOS ships with BSD `sed`. These have incompatibilities in the `-i` flag.

I implemented the solution described here: https://stackoverflow.com/a/22084103/4205735

(Note that I also use `-E` instead of `-r`; `-E` is recommended for portability.)

2. `clang++` as compiler

Because clang/llvm is the default compiler on macOS, it can be very difficult to properly set up a GCC-based toolchain. (Most easy installations of packages are based things that were precompiled with clang).

I added `makefile.llvm` so that this can be built with `make COMP=llvm`. The default locations for GSL and Eigen are where they can be found if you install them with `brew`.

With this setup, installation on a Mac should be, e.g.:

```
brew install open-mpi gsl eigen
cd src && make COMP=llvm static
```

I do get warnings about using the `-lomp` flag when it isn't needed, and noticed some warnings about checking MPI type sizes. However, I was able to run nnp-train on the LJ example with no problem.

***

Additionally, I added a `clean-no-docs` target to the makefile. If you don't have sphinx installed, `make clean` will error.