### PR TITLE
Avoid "fake" extrapolation warnings

### DIFF
--- a/src/libnnp/Element.cpp
+++ b/src/libnnp/Element.cpp
@@ -360,8 +360,11 @@ void Element::calculateSymmetryFunctionGroups(Atom&      atom,
     return;
 }
 
-void Element::updateSymmetryFunctionStatistics(Atom const& atom)
+size_t Element::updateSymmetryFunctionStatistics(Atom const& atom)
 {
+    size_t countExtrapolationWarnings = 0;
+    double epsilon = 10.0 * numeric_limits<double>::epsilon();
+
     if (atom.element != index)
     {
         throw runtime_error("ERROR: Atom has a different element index.\n");
@@ -384,8 +387,10 @@ void Element::updateSymmetryFunctionStatistics(Atom const& atom)
             statistics.addValue(index, value);
         }
 
-        if (value < Gmin || value > Gmax)
+        // Avoid "fake" EWs at the boundaries.
+        if (value + epsilon < Gmin || value - epsilon > Gmax)
         {
+            countExtrapolationWarnings++;
             if (statistics.collectExtrapolationWarnings)
             {
                 statistics.addExtrapolationWarning(index,
@@ -424,5 +429,5 @@ void Element::updateSymmetryFunctionStatistics(Atom const& atom)
         }
     }
 
-    return;
+    return countExtrapolationWarnings;
 }

--- a/src/libnnp/Element.h
+++ b/src/libnnp/Element.h
@@ -161,9 +161,11 @@ public:
      *
      * @param[in] atom Atom with symmetry function values.
      *
+     * @return Number of extrapolation warnings encountered.
+     *
      * This function checks also for extrapolation warnings.
      */
-    void                     updateSymmetryFunctionStatistics(
+    std::size_t              updateSymmetryFunctionStatistics(
                                                              Atom const& atom);
     /** Get symmetry function instance.
      *

--- a/src/libnnp/Settings.cpp
+++ b/src/libnnp/Settings.cpp
@@ -199,6 +199,11 @@ void Settings::parseLines()
         {
             continue;
         }
+        // check for empty lines in Windows format
+        if (line == "\r")
+        {
+            continue;
+        }
         if (line.find('#') != string::npos)
         {
             line.erase(line.find('#'));
@@ -260,7 +265,9 @@ size_t Settings::sanityCheck()
         {
             countProblems++;
             log.push_back(strpr(
-                "WARNING: Unknown keyword \"%s\".\n", (*it).first.c_str()));
+                "WARNING: Unknown keyword \"%s\" at line %zu.\n",
+                (*it).first.c_str(),
+                (*it).second.second + 1));
         }
     }
 

--- a/src/libnnp/version.h
+++ b/src/libnnp/version.h
@@ -18,8 +18,8 @@
 #define VERSION_H
 
 #define NNP_VERSION "2.0.0"
-#define NNP_GIT_REV "e7a29759d35de1e94b09bf88b270a76e20f41323"
-#define NNP_GIT_REV_SHORT "e7a2975"
+#define NNP_GIT_REV "8eacfab94d1a20437cace03c747d43b795606c4f"
+#define NNP_GIT_REV_SHORT "8eacfab"
 #define NNP_GIT_BRANCH "master"
 
 #endif

--- a/src/libnnpif/InterfaceLammps.cpp
+++ b/src/libnnpif/InterfaceLammps.cpp
@@ -214,6 +214,8 @@ void InterfaceLammps::setLocalAtoms(int              numAtomsLocal,
         a.hasSymmetryFunctions           = false;
         a.hasSymmetryFunctionDerivatives = false;
         a.neighbors.clear();
+        a.numNeighborsPerElement.clear();
+        a.numNeighborsPerElement.resize(numElements, 0);
         structure.numAtomsPerElement[a.element]++;
     }
 
@@ -232,6 +234,7 @@ void InterfaceLammps::addNeighbor(int    i,
     Atom& a = structure.atoms[i];
     a.numNeighbors++;
     a.neighbors.push_back(Atom::Neighbor());
+    a.numNeighborsPerElement.at(type - 1)++;
     Atom::Neighbor& n = a.neighbors.back();
     n.index   = j;
     n.tag     = tag;


### PR DESCRIPTION
- These happen at the boundaries due to rounding errors, mostly when
atoms have no or only a single neighbor -> symmetry function returns 0.
- Fixed newline bug for "input.nn" files created in Windows.