### PR TITLE
Fix Kalman Filter observation note when not using forces

### DIFF
--- a/src/libnnptrain/Training.cpp
+++ b/src/libnnptrain/Training.cpp
@@ -1090,7 +1090,7 @@ void Training::setupTraining()
                 log << "      size corresponds to error vector size:\n";
                 log << strpr("sizeObservation = %zu (energy updates)\n",
                              errorE.at(i).size());
-                if (useforces)
+                if (useForces)
                 {
                     log << strpr("sizeObservation = %zu (force  updates)\n",
                                  errorF.at(i).size());

--- a/src/libnnptrain/Training.cpp
+++ b/src/libnnptrain/Training.cpp
@@ -1090,8 +1090,11 @@ void Training::setupTraining()
                 log << "      size corresponds to error vector size:\n";
                 log << strpr("sizeObservation = %zu (energy updates)\n",
                              errorE.at(i).size());
-                log << strpr("sizeObservation = %zu (force  updates)\n",
-                             errorF.at(i).size());
+                if (useforces)
+                {
+                    log << strpr("sizeObservation = %zu (force  updates)\n",
+                                 errorF.at(i).size());
+                }
             }
             log << "-----------------------------------------"
                    "--------------------------------------\n";


### PR DESCRIPTION
Hello!

Training without forces using a Kalman Filter raises an out of range error on my computer. The culprit seems to be the line below, which was introduced in one of your recent commits (https://github.com/CompPhysVienna/n2p2/commit/4a25d7ad271f260d70a0485e870a352ec83f4453).
```
log << strpr("sizeObservation = %zu (force  updates)\n",
                             errorF.at(i).size());
```
Everything seems to work fine if we first check the `useForces` flag.

Cheers,

Jérémy Lauret