### PR TITLE
Fixed bug in nnp-dist

### DIFF
--- a/src/application/nnp-dist.cpp
+++ b/src/application/nnp-dist.cpp
@@ -233,10 +233,13 @@ int main(int argc, char* argv[])
                         {
                             countAngles += ahist.at(i)[e]->at(n);
                         }
-                        for (size_t n = 0; n < numBins; ++n)
+                        if (countAngles > 0)
                         {
-                            adf.at(i)[e]->at(n) += ahist.at(i)[e]->at(n)
-                                                 / countAngles / da;
+                            for (size_t n = 0; n < numBins; ++n)
+                            {
+                                adf.at(i)[e]->at(n) += ahist.at(i)[e]->at(n)
+                                                     / countAngles / da;
+                            }
                         }
                         ahist.at(i)[e]->clear();
                         ahist.at(i)[e]->resize(numBins, 0.0);

--- a/src/libnnp/version.h
+++ b/src/libnnp/version.h
@@ -18,8 +18,8 @@
 #define VERSION_H
 
 #define NNP_VERSION "2.0.0"
-#define NNP_GIT_REV "de8ab80c0d47c1c8d0ec98c04133fbb45b76af02"
-#define NNP_GIT_REV_SHORT "de8ab80"
-#define NNP_GIT_BRANCH "fix_element_nodes_short"
+#define NNP_GIT_REV "6c59866a54ef87e46714eb441294c699a07d7c65"
+#define NNP_GIT_REV_SHORT "6c59866"
+#define NNP_GIT_BRANCH "master"
 
 #endif


### PR DESCRIPTION
- NaN in ADF when some cfgs have no corresponding angles to add.