### PR TITLE
More error metrics

### DIFF
--- a/examples/input.nn.recommended
+++ b/examples/input.nn.recommended
@@ -50,6 +50,7 @@ weights_min                     -1.0           # Minimum value for initial rando
 weights_max                     1.0            # Maximum value for initial random weights.
 #precondition_weights                           # Precondition weights with initial energies.
 #nguyen_widrow_weights_short                    # Initialize neural network weights according to Nguyen-Widrow scheme.
+main_error_metric               RMSEpa         # Main error metric for screen output (RMSEpa/RMSE/MAEpa/MAE).
 write_trainpoints               1              # Write energy comparison every this many epochs.
 write_trainforces               1              # Write force comparison every this many epochs.
 write_weights_epoch             1              # Write weights every this many epochs.

--- a/examples/nnp-train/Cu2S_PBE/input.nn
+++ b/examples/nnp-train/Cu2S_PBE/input.nn
@@ -33,7 +33,6 @@ global_activation_short         p p l          # Activation function for each hi
 # nnp-comp2, nnp-scaling, nnp-dataset, nnp-train.
 use_short_forces                               # Use forces.
 random_seed                     1234567        # Random number generator seed.
-main_error_metric               RMSEpa         # Main error metric for screen output (RMSEpa/RMSE/MAEpa/MAE).
 
 ###############################################################################
 # ADDITIONAL SETTINGS FOR TRAINING
@@ -60,6 +59,7 @@ weights_min                     -1.0           # Minimum value for initial rando
 weights_max                     1.0            # Maximum value for initial random weights.
 #precondition_weights                           # Precondition weights with initial energies.
 #nguyen_widrow_weights_short                    # Initialize neural network weights according to Nguyen-Widrow scheme.
+main_error_metric               RMSEpa         # Main error metric for screen output (RMSEpa/RMSE/MAEpa/MAE).
 write_trainpoints               1              # Write energy comparison every this many epochs.
 write_trainforces               1              # Write force comparison every this many epochs.
 write_weights_epoch             1              # Write weights every this many epochs.

--- a/examples/nnp-train/Cu2S_PBE/input.nn
+++ b/examples/nnp-train/Cu2S_PBE/input.nn
@@ -33,6 +33,7 @@ global_activation_short         p p l          # Activation function for each hi
 # nnp-comp2, nnp-scaling, nnp-dataset, nnp-train.
 use_short_forces                               # Use forces.
 random_seed                     1234567        # Random number generator seed.
+main_error_metric               RMSEpa         # Main error metric for screen output (RMSEpa/RMSE/MAEpa/MAE).
 
 ###############################################################################
 # ADDITIONAL SETTINGS FOR TRAINING

--- a/examples/nnp-train/H2O_RPBE-D3/input.nn
+++ b/examples/nnp-train/H2O_RPBE-D3/input.nn
@@ -33,6 +33,7 @@ global_activation_short         t t l          # Activation function for each hi
 # nnp-comp2, nnp-scaling, nnp-dataset, nnp-train.
 use_short_forces                               # Use forces.
 random_seed                     1234567        # Random number generator seed.
+main_error_metric               RMSEpa         # Main error metric for screen output (RMSEpa/RMSE/MAEpa/MAE).
 
 ###############################################################################
 # ADDITIONAL SETTINGS FOR TRAINING

--- a/examples/nnp-train/H2O_RPBE-D3/input.nn
+++ b/examples/nnp-train/H2O_RPBE-D3/input.nn
@@ -33,7 +33,6 @@ global_activation_short         t t l          # Activation function for each hi
 # nnp-comp2, nnp-scaling, nnp-dataset, nnp-train.
 use_short_forces                               # Use forces.
 random_seed                     1234567        # Random number generator seed.
-main_error_metric               RMSEpa         # Main error metric for screen output (RMSEpa/RMSE/MAEpa/MAE).
 
 ###############################################################################
 # ADDITIONAL SETTINGS FOR TRAINING
@@ -60,6 +59,7 @@ weights_min                     -1.0           # Minimum value for initial rando
 weights_max                     1.0            # Maximum value for initial random weights.
 #precondition_weights                           # Precondition weights with initial energies.
 #nguyen_widrow_weights_short                    # Initialize neural network weights according to Nguyen-Widrow scheme.
+main_error_metric               RMSEpa         # Main error metric for screen output (RMSEpa/RMSE/MAEpa/MAE).
 write_trainpoints               1              # Write energy comparison every this many epochs.
 write_trainforces               1              # Write force comparison every this many epochs.
 write_weights_epoch             1              # Write weights every this many epochs.

--- a/examples/nnp-train/LJ/input.nn
+++ b/examples/nnp-train/LJ/input.nn
@@ -23,7 +23,6 @@ global_activation_short         t l            # Activation function for each hi
 # nnp-comp2, nnp-scaling, nnp-dataset, nnp-train.
 use_short_forces                               # Use forces.
 random_seed                     1234567        # Random number generator seed.
-main_error_metric               RMSEpa         # Main error metric for screen output (RMSEpa/RMSE/MAEpa/MAE).
 
 ###############################################################################
 # ADDITIONAL SETTINGS FOR TRAINING
@@ -50,6 +49,7 @@ weights_min                     -1.0           # Minimum value for initial rando
 weights_max                     1.0            # Maximum value for initial random weights.
 #precondition_weights                           # Precondition weights with initial energies.
 #nguyen_widrow_weights_short                    # Initialize neural network weights according to Nguyen-Widrow scheme.
+main_error_metric               RMSEpa         # Main error metric for screen output (RMSEpa/RMSE/MAEpa/MAE).
 write_trainpoints               1              # Write energy comparison every this many epochs.
 write_trainforces               1              # Write force comparison every this many epochs.
 write_weights_epoch             1              # Write weights every this many epochs.

--- a/examples/nnp-train/LJ/input.nn
+++ b/examples/nnp-train/LJ/input.nn
@@ -23,6 +23,7 @@ global_activation_short         t l            # Activation function for each hi
 # nnp-comp2, nnp-scaling, nnp-dataset, nnp-train.
 use_short_forces                               # Use forces.
 random_seed                     1234567        # Random number generator seed.
+main_error_metric               RMSEpa         # Main error metric for screen output (RMSEpa/RMSE/MAEpa/MAE).
 
 ###############################################################################
 # ADDITIONAL SETTINGS FOR TRAINING

--- a/src/doc/sphinx/source/Tools/nnp-prune.rst
+++ b/src/doc/sphinx/source/Tools/nnp-prune.rst
@@ -50,7 +50,7 @@ symmetry functions with a sensitivity below the threshold:
 
 .. code-block:: bash
 
-   nnp-prune sensitivity 0.5
+   nnp-prune sensitivity 0.5 max
 
 Here, the threshold is set to 0.5% where 100% is equal to the total sum of all
 sensitivities. The resulting settings file is called

--- a/src/doc/sphinx/source/Topics/keywords.rst
+++ b/src/doc/sphinx/source/Topics/keywords.rst
@@ -377,6 +377,34 @@ implemented:
   so far is used. This selection scheme is a variation of the adaptive process
   described by Blank and Brown [1]_ and is described here [2]_.
 
+----
+
+``main_error_metric``
+^^^^^^^^^^^^^^^^^^^^^
+
+**Usage**:
+   ``main_error_metric <string>``
+
+**Examples**:
+   ``main_error_metric RMSEpa``
+
+   ``main_error_metric MAE``
+
+Selects the error metric to display on the screen during training. Four variants
+are available:
+
+* ``RMSEpa``: RMSE of energies per atom, RMSE of forces.
+
+* ``RMSE``: RMSE of energies, RMSE of forces.
+
+* ``MAEpa``: MAE of energies per atom, MAE of forces.
+
+* ``MAE``: MAE of energies, MAE of forces.
+
+If this keyword is omitted the default value is ``RMSEpa``. The keyword does not
+influence the output in the ``learning-curve.out`` file. There, all error metrics
+are written.
+
 .. [1] Blank, T. B.; Brown, S. D. Adaptive, Global, Extended Kalman Filters for
    Training Feedforward Neural Networks. J. Chemom. 1994, 8 (6), 391–407.
    https://doi.org/10.1002/cem.1180080605

--- a/src/libnnp/Atom.cpp
+++ b/src/libnnp/Atom.cpp
@@ -266,10 +266,11 @@ size_t Atom::getNumNeighbors(double cutoffRadius) const
     return numNeighborsLocal;
 }
 
-void Atom::updateRmseForces(double& rmse, size_t& count) const
+void Atom::updateErrorForces(vector<double>& error, size_t& count) const
 {
     count += 3;
-    rmse += (fRef - f).norm2();
+    error.at(0) += (fRef - f).norm2();
+    error.at(1) += (fRef - f).l1norm();
 
     return;
 }

--- a/src/libnnp/Atom.h
+++ b/src/libnnp/Atom.h
@@ -222,13 +222,14 @@ struct Atom
      * smaller cutoff is requested.
      */
     std::size_t              getNumNeighbors(double cutoffRadius) const;
-    /** Update force RMSE with forces of this atom.
+    /** Update force error metrices with forces of this atom.
      *
-     * @param[in,out] rmse Input RMSE to be updated.
+     * @param[in,out] error Input error metric vector to be updated.
      * @param[in,out] count Input counter to be updated.
      */
-    void                     updateRmseForces(double&      rmse,
-                                              std::size_t& count) const;
+    void                     updateErrorForces(
+                                             std::vector<double>& rmse,
+                                             std::size_t&         count) const;
     /** Get reference and NN forces for this atoms.
      *
      * @return Vector of strings with #indexStructure, #index, #fRef, #f

--- a/src/libnnp/Settings.cpp
+++ b/src/libnnp/Settings.cpp
@@ -48,6 +48,7 @@ map<string, string> const createKnownKeywordsMap()
 
     // Training keywords.
     m["random_seed"                   ] = "";
+    m["main_error_metric"             ] = "";
     m["test_fraction"                 ] = "";
     m["epochs"                        ] = "";
     m["use_short_forces"              ] = "";

--- a/src/libnnp/Settings.cpp
+++ b/src/libnnp/Settings.cpp
@@ -48,7 +48,6 @@ map<string, string> const createKnownKeywordsMap()
 
     // Training keywords.
     m["random_seed"                   ] = "";
-    m["main_error_metric"             ] = "";
     m["test_fraction"                 ] = "";
     m["epochs"                        ] = "";
     m["use_short_forces"              ] = "";
@@ -62,6 +61,7 @@ map<string, string> const createKnownKeywordsMap()
     m["weights_max"                   ] = "";
     m["nguyen_widrow_weights_short"   ] = "";
     m["precondition_weights"          ] = "";
+    m["main_error_metric"             ] = "";
     m["write_trainpoints"             ] = "";
     m["write_trainforces"             ] = "";
     m["write_weights_epoch"           ] = "";

--- a/src/libnnp/Structure.cpp
+++ b/src/libnnp/Structure.cpp
@@ -573,21 +573,25 @@ void Structure::clearNeighborList()
     return;
 }
 
-void Structure::updateRmseEnergy(double& rmse, size_t& count) const
+void Structure::updateErrorEnergy(vector<double>& error, size_t& count) const
 {
     count++;
-    rmse += (energyRef - energy) * (energyRef - energy)
-          / (numAtoms * numAtoms);
+    double diff = energyRef - energy;
+    error.at(0) += diff * diff / (numAtoms * numAtoms);
+    error.at(1) += diff * diff;
+    diff = fabs(diff);
+    error.at(2) += diff / numAtoms;
+    error.at(3) += diff;
 
     return;
 }
 
-void Structure::updateRmseForces(double& rmse, size_t& count) const
+void Structure::updateErrorForces(vector<double>& error, size_t& count) const
 {
     for (vector<Atom>::const_iterator it = atoms.begin();
          it != atoms.end(); ++it)
     {
-        it->updateRmseForces(rmse, count);
+        it->updateErrorForces(error, count);
     }
 
     return;

--- a/src/libnnp/Structure.h
+++ b/src/libnnp/Structure.h
@@ -233,20 +233,36 @@ struct Structure
     /** Clear neighbor list of all atoms.
      */
     void                     clearNeighborList();
-    /** Update energy RMSE with this structure.
+    /** Update energy error metrices with this structure.
      *
-     * @param[in,out] rmse Input RMSE to be updated.
+     * @param[in,out] error Input error metric vector to be updated.
      * @param[in,out] count Input counter to be updated.
-     */
-    void                     updateRmseEnergy(double&      rmse,
-                                              std::size_t& count) const;
-    /** Update force RMSE with all atoms of this structure.
      *
-     * @param[in,out] rmse Input RMSE to be updated.
-     * @param[in,out] count Input counter to be updated.
+     * The error metric vector stores temporary sums for the following
+     * metrices:
+     *
+     * index 0: RMSE of energy per atom
+     * index 1: RMSE of energy
+     * index 2: MAE  of energy per atom
+     * index 3: MAE  of energy
      */
-    void                     updateRmseForces(double&      rmse,
-                                              std::size_t& count) const;
+    void                     updateErrorEnergy(
+                                             std::vector<double>& error,
+                                             std::size_t&         count) const;
+    /** Update force error metrices with all atoms of this structure.
+     *
+     * @param[in,out] error Input error metric vector to be updated.
+     * @param[in,out] count Input counter to be updated.
+     *
+     * The error metric vector stores temporary sums for the following
+     * metrices:
+     *
+     * index 0: RMSE of forces
+     * index 1: MAE  of forces
+     */
+    void                     updateErrorForces(
+                                             std::vector<double>& error,
+                                             std::size_t&         count) const;
     /** Get reference and NN energy.
      *
      * @return String with #index, #energyRef and #energy values.

--- a/src/libnnp/Vec3D.h
+++ b/src/libnnp/Vec3D.h
@@ -99,6 +99,11 @@ struct Vec3D
      * @return Square of norm of vector.
      */
     double        norm2() const;
+    /** Calculate l1 norm of vector (taxicab metric).
+     *
+     * @return L1-norm of vector.
+     */
+    double        l1norm() const;
     /** Normalize vector, norm equals 1.0 afterwards.
      */
     Vec3D&        normalize();
@@ -256,6 +261,11 @@ inline double Vec3D::norm() const
 inline double Vec3D::norm2() const
 {
     return r[0] * r[0] + r[1] * r[1] + r[2] * r[2];
+}
+
+inline double Vec3D::l1norm() const
+{
+    return fabs(r[0]) + fabs(r[1]) + fabs(r[2]);
 }
 
 inline Vec3D& Vec3D::normalize()

--- a/src/libnnp/version.h
+++ b/src/libnnp/version.h
@@ -18,8 +18,8 @@
 #define VERSION_H
 
 #define NNP_VERSION "2.0.0"
-#define NNP_GIT_REV "6c59866a54ef87e46714eb441294c699a07d7c65"
-#define NNP_GIT_REV_SHORT "6c59866"
-#define NNP_GIT_BRANCH "master"
+#define NNP_GIT_REV "f2d11ee2afb3566ade57e9e5acdf6451cbe7384a"
+#define NNP_GIT_REV_SHORT "f2d11ee"
+#define NNP_GIT_BRANCH "more-error-metrics"
 
 #endif

--- a/src/libnnp/version.h
+++ b/src/libnnp/version.h
@@ -18,8 +18,8 @@
 #define VERSION_H
 
 #define NNP_VERSION "2.0.0"
-#define NNP_GIT_REV "f2d11ee2afb3566ade57e9e5acdf6451cbe7384a"
-#define NNP_GIT_REV_SHORT "f2d11ee"
+#define NNP_GIT_REV "d2b2114316b4c4df4df16448b5d908e656ef8fa4"
+#define NNP_GIT_REV_SHORT "d2b2114"
 #define NNP_GIT_BRANCH "more-error-metrics"
 
 #endif

--- a/src/libnnptrain/Dataset.cpp
+++ b/src/libnnptrain/Dataset.cpp
@@ -1477,11 +1477,28 @@ void Dataset::writeAtomicEnvironmentFile(
     return;
 }
 
-void Dataset::averageRmse(double& rmse, size_t& count) const
+void Dataset::collectErrorEnergies(vector<double>& error, size_t& count) const
 {
-    MPI_Allreduce(MPI_IN_PLACE, &count, 1, MPI_SIZE_T, MPI_SUM, comm);
-    MPI_Allreduce(MPI_IN_PLACE, &rmse , 1, MPI_DOUBLE, MPI_SUM, comm);
-    rmse = sqrt(rmse / count);
+    MPI_Allreduce(MPI_IN_PLACE, &count         , 1, MPI_SIZE_T, MPI_SUM, comm);
+    MPI_Allreduce(MPI_IN_PLACE, &(error.at(0)) , 1, MPI_DOUBLE, MPI_SUM, comm);
+    MPI_Allreduce(MPI_IN_PLACE, &(error.at(1)) , 1, MPI_DOUBLE, MPI_SUM, comm);
+    MPI_Allreduce(MPI_IN_PLACE, &(error.at(2)) , 1, MPI_DOUBLE, MPI_SUM, comm);
+    MPI_Allreduce(MPI_IN_PLACE, &(error.at(3)) , 1, MPI_DOUBLE, MPI_SUM, comm);
+    error.at(0) = sqrt(error.at(0) / count);
+    error.at(1) = sqrt(error.at(1) / count);
+    error.at(2) = error.at(2) / count;
+    error.at(3) = error.at(3) / count;
+
+    return;
+}
+
+void Dataset::collectErrorForces(vector<double>& error, size_t& count) const
+{
+    MPI_Allreduce(MPI_IN_PLACE, &count         , 1, MPI_SIZE_T, MPI_SUM, comm);
+    MPI_Allreduce(MPI_IN_PLACE, &(error.at(0)) , 1, MPI_DOUBLE, MPI_SUM, comm);
+    MPI_Allreduce(MPI_IN_PLACE, &(error.at(1)) , 1, MPI_DOUBLE, MPI_SUM, comm);
+    error.at(0) = sqrt(error.at(0) / count);
+    error.at(1) = error.at(1) / count;
 
     return;
 }

--- a/src/libnnptrain/Dataset.h
+++ b/src/libnnptrain/Dataset.h
@@ -159,14 +159,14 @@ public:
                                         bool                     derivatives,
                                         std::string const &      fileNamePrefix
                                              = "atomic-env");
-    /** Collect error metrices of energies over all MPI procs.
+    /** Collect error metrics of energies over all MPI procs.
      *
      * @param[in,out] error Metric sums of this proc (in), global metric (out).
      * @param[in,out] count Count for this proc (in), global count (out).
      */
     void        collectErrorEnergies(std::vector<double>& error,
                                      std::size_t&         count) const;
-    /** Collect error metrices of forces over all MPI procs.
+    /** Collect error metrics of forces over all MPI procs.
      *
      * @param[in,out] error Metric sums of this proc (in), global metric (out).
      * @param[in,out] count Count for this proc (in), global count (out).

--- a/src/libnnptrain/Dataset.h
+++ b/src/libnnptrain/Dataset.h
@@ -159,12 +159,20 @@ public:
                                         bool                     derivatives,
                                         std::string const &      fileNamePrefix
                                              = "atomic-env");
-    /** Reduce and average RMSE over all MPI procs.
+    /** Collect error metrices of energies over all MPI procs.
      *
-     * @param[in,out] rmse RMSE sum of this proc (in), global RMSE (out).
+     * @param[in,out] error Metric sums of this proc (in), global metric (out).
      * @param[in,out] count Count for this proc (in), global count (out).
      */
-    void        averageRmse(double& rmse, std::size_t& count) const;
+    void        collectErrorEnergies(std::vector<double>& error,
+                                     std::size_t&         count) const;
+    /** Collect error metrices of forces over all MPI procs.
+     *
+     * @param[in,out] error Metric sums of this proc (in), global metric (out).
+     * @param[in,out] count Count for this proc (in), global count (out).
+     */
+    void        collectErrorForces(std::vector<double>& error,
+                                     std::size_t&       count) const;
     /** Combine individual MPI proc files to one.
      *
      * @param[in] filePrefix File prefix without the ".0001" suffix.

--- a/src/libnnptrain/Training.cpp
+++ b/src/libnnptrain/Training.cpp
@@ -83,7 +83,7 @@ Training::Training() : Dataset(),
                        forceWeight                (0.0            ),
                        trainingLogFileName        ("train-log.out")
 {
-    // Set up error metrices
+    // Set up error metrics
     errorEnergiesTrain.resize(4, 0.0);
     errorEnergiesTest.resize(4, 0.0);
     errorForcesTrain.resize(2, 0.0);
@@ -1205,7 +1205,7 @@ void Training::calculateError(bool const   writeCompFiles,
     ofstream fileForcesTrain;
     ofstream fileForcesTest;
 
-    // Reset current error metrices.
+    // Reset current error metrics.
     fill(errorEnergiesTrain.begin(), errorEnergiesTrain.end(), 0.0);
     fill(errorEnergiesTest.begin() , errorEnergiesTest.end() , 0.0);
     fill(errorForcesTrain.begin()  , errorForcesTrain.end()  , 0.0);
@@ -1491,33 +1491,89 @@ void Training::writeLearningCurve(bool append, string const fileName) const
         colName.push_back("epoch");
         colInfo.push_back("Current epoch.");
         colSize.push_back(16);
-        colName.push_back("rmse_Etrain_phys");
+        colName.push_back("RMSEpa_Etrain_pu");
         colInfo.push_back("RMSE of training energies per atom (physical "
                           "units).");
         colSize.push_back(16);
-        colName.push_back("rmse_Etest_phys");
+        colName.push_back("RMSEpa_Etest_pu");
         colInfo.push_back("RMSE of test energies per atom (physical units).");
         colSize.push_back(16);
-        colName.push_back("rmse_Ftrain_phys");
+        colName.push_back("RMSE_Ftrain_pu");
         colInfo.push_back("RMSE of training forces (physical units).");
         colSize.push_back(16);
-        colName.push_back("rmse_Ftest_phys");
+        colName.push_back("RMSE_Ftest_pu");
         colInfo.push_back("RMSE of test forces (physical units).");
+        colSize.push_back(16);
+        colName.push_back("RMSE_Etrain_pu");
+        colInfo.push_back("RMSE of training energies (physical "
+                          "units).");
+        colSize.push_back(16);
+        colName.push_back("RMSE_Etest_pu");
+        colInfo.push_back("RMSE of test energies (physical units).");
+        colSize.push_back(16);
+        colName.push_back("MAEpa_Etrain_pu");
+        colInfo.push_back("MAE of training energies per atom (physical "
+                          "units).");
+        colSize.push_back(16);
+        colName.push_back("MAEpa_Etest_pu");
+        colInfo.push_back("MAE of test energies per atom (physical units).");
+        colSize.push_back(16);
+        colName.push_back("MAE_Ftrain_pu");
+        colInfo.push_back("MAE of training forces (physical units).");
+        colSize.push_back(16);
+        colName.push_back("MAE_Ftest_pu");
+        colInfo.push_back("MAE of test forces (physical units).");
+        colSize.push_back(16);
+        colName.push_back("MAE_Etrain_pu");
+        colInfo.push_back("MAE of training energies (physical "
+                          "units).");
+        colSize.push_back(16);
+        colName.push_back("MAE_Etest_pu");
+        colInfo.push_back("MAE of test energies (physical units).");
         if (normalize)
         {
             colSize.push_back(16);
-            colName.push_back("rmse_Etrain_int");
+            colName.push_back("RMSEpa_Etrain_iu");
             colInfo.push_back("RMSE of training energies per atom (internal "
                               "units).");
             colSize.push_back(16);
-            colName.push_back("rmse_Etest_int");
-            colInfo.push_back("RMSE of test energies per atom (internal units).");
+            colName.push_back("RMSEpa_Etest_iu");
+            colInfo.push_back("RMSE of test energies per atom (internal "
+                              "units).");
             colSize.push_back(16);
-            colName.push_back("rmse_Ftrain_int");
+            colName.push_back("RMSE_Ftrain_iu");
             colInfo.push_back("RMSE of training forces (internal units).");
             colSize.push_back(16);
-            colName.push_back("rmse_Ftest_int");
+            colName.push_back("RMSE_Ftest_iu");
             colInfo.push_back("RMSE of test forces (internal units).");
+            colSize.push_back(16);
+            colName.push_back("RMSE_Etrain_iu");
+            colInfo.push_back("RMSE of training energies (internal "
+                              "units).");
+            colSize.push_back(16);
+            colName.push_back("RMSE_Etest_iu");
+            colInfo.push_back("RMSE of test energies (internal units).");
+            colSize.push_back(16);
+            colName.push_back("MAEpa_Etrain_iu");
+            colInfo.push_back("MAE of training energies per atom (internal "
+                              "units).");
+            colSize.push_back(16);
+            colName.push_back("MAEpa_Etest_iu");
+            colInfo.push_back("MAE of test energies per atom (internal "
+                              "units).");
+            colSize.push_back(16);
+            colName.push_back("MAE_Ftrain_iu");
+            colInfo.push_back("MAE of training forces (internal units).");
+            colSize.push_back(16);
+            colName.push_back("MAE_Ftest_iu");
+            colInfo.push_back("MAE of test forces (internal units).");
+            colSize.push_back(16);
+            colName.push_back("MAE_Etrain_iu");
+            colInfo.push_back("MAE of training energies (internal "
+                              "units).");
+            colSize.push_back(16);
+            colName.push_back("MAE_Etest_iu");
+            colInfo.push_back("MAE of test energies (internal units).");
         }
         appendLinesToFile(file,
                           createFileHeader(title, colSize, colName, colInfo));
@@ -1526,17 +1582,35 @@ void Training::writeLearningCurve(bool append, string const fileName) const
     file << strpr("%10zu", epoch);
     if (normalize)
     {
-        file << strpr(" %16.8E %16.8E %16.8E %16.8E",
+        file << strpr(" %16.8E %16.8E %16.8E %16.8E %16.8E %16.8E"
+                      " %16.8E %16.8E %16.8E %16.8E %16.8E %16.8E",
                       physicalEnergy(errorEnergiesTrain.at(0)),
                       physicalEnergy(errorEnergiesTest.at(0)),
                       physicalForce(errorForcesTrain.at(0)),
-                      physicalForce(errorForcesTest.at(0)));
+                      physicalForce(errorForcesTest.at(0)),
+                      physicalEnergy(errorEnergiesTrain.at(1)),
+                      physicalEnergy(errorEnergiesTest.at(1)),
+                      physicalEnergy(errorEnergiesTrain.at(2)),
+                      physicalEnergy(errorEnergiesTest.at(2)),
+                      physicalForce(errorForcesTrain.at(1)),
+                      physicalForce(errorForcesTest.at(1)),
+                      physicalEnergy(errorEnergiesTrain.at(3)),
+                      physicalEnergy(errorEnergiesTest.at(3)));
     }
-    file << strpr(" %16.8E %16.8E %16.8E %16.8E\n",
+    file << strpr(" %16.8E %16.8E %16.8E %16.8E %16.8E %16.8E"
+                  " %16.8E %16.8E %16.8E %16.8E %16.8E %16.8E\n",
                   errorEnergiesTrain.at(0),
                   errorEnergiesTest.at(0),
                   errorForcesTrain.at(0),
-                  errorForcesTest.at(0));
+                  errorForcesTest.at(0),
+                  errorEnergiesTrain.at(1),
+                  errorEnergiesTest.at(1),
+                  errorEnergiesTrain.at(2),
+                  errorEnergiesTest.at(2),
+                  errorForcesTrain.at(1),
+                  errorForcesTest.at(1),
+                  errorEnergiesTrain.at(3),
+                  errorEnergiesTest.at(3));
     file.close();
 
     return;
@@ -1804,24 +1878,34 @@ void Training::loop()
            "**************************************\n";
     log << "\n";
 
+    string metric = "";
+    string peratom = "";
+    if (errorMetricForces == 0) metric = "RMSE";
+    else if (errorMetricForces == 1) metric = "MAE";
+    if (errorMetricEnergies % 2 == 0) peratom = "per atom ";
+
     log << "The training loop output covers different RMSEs, update and\n";
     log << "timing information. The following quantities are organized\n";
     log << "according to the matrix scheme below:\n";
     log << "-------------------------------------------------------------------\n";
     log << "ep ............ Epoch.\n";
-    log << "Etrain_phys ... RMSE of training energies per atom (p. u.).\n";
-    log << "Etest_phys .... RMSE of test     energies per atom (p. u.).\n";
-    log << "Etrain_int .... RMSE of training energies per atom (i. u.).\n";
-    log << "Etest_int ..... RMSE of test     energies per atom (i. u.).\n";
-    log << "Ftrain_phys ... RMSE of training forces (p. u.).\n";
-    log << "Ftest_phys .... RMSE of test     forces (p. u.).\n";
-    log << "Ftrain_int .... RMSE of training forces (i. u.).\n";
-    log << "Ftest_int ..... RMSE of test     forces (i. u.).\n";
+    log << "Etrain_phys ... " << metric << " of training energies "
+        << peratom << "(p. u.).\n";
+    log << "Etest_phys .... " << metric << " of test     energies "
+        << peratom << "(p. u.).\n";
+    log << "Etrain_int .... " << metric << " of training energies "
+        << peratom << "(i. u.).\n";
+    log << "Etest_int ..... " << metric << " of test     energies "
+        << peratom << "(i. u.).\n";
+    log << "Ftrain_phys ... " << metric << " of training forces (p. u.).\n";
+    log << "Ftest_phys .... " << metric << " of test     forces (p. u.).\n";
+    log << "Ftrain_int .... " << metric << " of training forces (i. u.).\n";
+    log << "Ftest_int ..... " << metric << " of test     forces (i. u.).\n";
     log << "E_count ....... Number of energy updates.\n";
     log << "F_count ....... Number of force  updates.\n";
     log << "count ......... Total number of updates.\n";
     log << "t_train ....... Time for training (seconds).\n";
-    log << "t_rmse ........ Time for RMSE calculation (seconds).\n";
+    log << "t_error ....... Time for error calculation (seconds).\n";
     log << "t_epoch ....... Total time for this epoch (seconds).\n";
     log << "t_tot ......... Total time for all epochs (seconds).\n";
     log << "Abbreviations:\n";
@@ -1834,7 +1918,7 @@ void Training::loop()
     log << "energy   ep   Etrain_phys    Etest_phys    Etrain_int     Etest_int\n";
     log << "forces   ep   Ftrain_phys    Ftest_phys    Ftrain_int     Ftest_int\n";
     log << "update   ep       E_count       F_count         count\n";
-    log << "timing   ep       t_train        t_rmse       t_epoch         t_tot\n";
+    log << "timing   ep       t_train       t_error       t_epoch         t_tot\n";
     log << "-------------------------------------------------------------------\n";
 
     // Set up stopwatch.

--- a/src/libnnptrain/Training.h
+++ b/src/libnnptrain/Training.h
@@ -138,7 +138,7 @@ public:
     /** Calculate neighbor lists for all structures.
      */
     void                  calculateNeighborLists();
-    /** Calculate error metrices for all structures.
+    /** Calculate error metrics for all structures.
      *
      * @param[in] writeCompFiles Write NN and reference energies and forces to
      *                           comparison files.
@@ -163,7 +163,7 @@ public:
                                             = "forces-train.comp",
                                         std::string const fileNameForcesTest
                                             = "forces-test.comp");
-    /** Calculate error metrices per epoch for all structures with file names
+    /** Calculate error metrics per epoch for all structures with file names
      * used in training loop.
      *
      * Also write training curve to file.
@@ -409,13 +409,13 @@ private:
     std::vector<std::size_t>      numWeightsPerUpdater;
     /// Offset of each element's weights in combined array.
     std::vector<std::size_t>      weightsOffset;
-    /// Current error metrices of training energies.
+    /// Current error metrics of training energies.
     std::vector<double>           errorEnergiesTrain;
-    /// Current error metrices of test energies.
+    /// Current error metrics of test energies.
     std::vector<double>           errorEnergiesTest;
-    /// Current error metrices of training forces.
+    /// Current error metrics of training forces.
     std::vector<double>           errorForcesTrain;
-    /// Current error metrices of test forces.
+    /// Current error metrics of test forces.
     std::vector<double>           errorForcesTest;
 #ifdef IMPROVED_SFD_MEMORY
     /// Derivative of symmetry functions with respect to one specific atom

--- a/src/libnnptrain/Training.h
+++ b/src/libnnptrain/Training.h
@@ -138,7 +138,7 @@ public:
     /** Calculate neighbor lists for all structures.
      */
     void                  calculateNeighborLists();
-    /** Calculate RMSE for all structures.
+    /** Calculate error metrices for all structures.
      *
      * @param[in] writeCompFiles Write NN and reference energies and forces to
      *                           comparison files.
@@ -151,7 +151,8 @@ public:
      *                                file.
      * @param[in] fileNameForcesTest File name for test forces comparison file.
      */
-    void                  calculateRmse(bool const        writeCompFiles,
+    void                  calculateError(
+                                        bool const        writeCompFiles,
                                         std::string const identifier           
                                             = "",
                                         std::string const fileNameEnergiesTrain
@@ -162,12 +163,12 @@ public:
                                             = "forces-train.comp",
                                         std::string const fileNameForcesTest
                                             = "forces-test.comp");
-    /** Calculate RMSE per epoch for all structures with file names used in
-     * training loop.
+    /** Calculate error metrices per epoch for all structures with file names
+     * used in training loop.
      *
      * Also write training curve to file.
      */
-    void                  calculateRmseEpoch();
+    void                  calculateErrorEpoch();
     /** Write weights to files (one file for each element).
      *
      * @param[in] fileNameFormat String with file name format.
@@ -376,18 +377,14 @@ private:
     std::size_t                   errorsGlobalForce;
     /// Total number of weights.
     std::size_t                   numWeights;
+    /// Error metric index for energies.
+    std::size_t                   errorMetricEnergies;
+    /// Error metric index for forces.
+    std::size_t                   errorMetricForces;
     /// Desired energy update fraction per epoch.
     double                        epochFractionEnergies;
     /// Desired force update fraction per epoch.
     double                        epochFractionForces;
-    /// Current RMSE of training energies.
-    double                        rmseEnergiesTrain;
-    /// Current RMSE of test energies.
-    double                        rmseEnergiesTest;
-    /// Current RMSE of training forces.
-    double                        rmseForcesTrain;
-    /// Current RMSE of test forces.
-    double                        rmseForcesTest;
     /// RMSE threshold for energy update candidates.
     double                        rmseThresholdEnergy;
     /// RMSE threshold for force update candidates.
@@ -412,6 +409,14 @@ private:
     std::vector<std::size_t>      numWeightsPerUpdater;
     /// Offset of each element's weights in combined array.
     std::vector<std::size_t>      weightsOffset;
+    /// Current error metrices of training energies.
+    std::vector<double>           errorEnergiesTrain;
+    /// Current error metrices of test energies.
+    std::vector<double>           errorEnergiesTest;
+    /// Current error metrices of training forces.
+    std::vector<double>           errorForcesTrain;
+    /// Current error metrices of test forces.
+    std::vector<double>           errorForcesTest;
 #ifdef IMPROVED_SFD_MEMORY
     /// Derivative of symmetry functions with respect to one specific atom
     /// coordinate.


### PR DESCRIPTION
Improve error reporting capabilities. Previously only the RMSE of per-atom-energies and forces was computed and reported. Now the following quantities are taken into account:

* RMSE of energies per atom
* RMSE of energies
* MAE of energies per atom
* MAE of energies
* RMSE of forces
* MAE of forces

All quantities will be written to `learning-curve.out` upon training. The output of `nnp-dataset` was also restructured to show all error metrics.