### PR TITLE
[WIP] Parallel decoupled Kalman filter training

### DIFF
--- a/src/libnnp/Settings.cpp
+++ b/src/libnnp/Settings.cpp
@@ -73,6 +73,7 @@ map<string, string> const createKnownKeywordsMap()
     m["jacobian_mode"                 ] = "";
     m["update_strategy"               ] = "";
     m["selection_mode"                ] = "";
+    m["decoupling_type"               ] = "";
     m["task_batch_size_energy"        ] = "";
     m["task_batch_size_force"         ] = "";
     m["gradient_type"                 ] = "";

--- a/src/libnnptrain/Training.cpp
+++ b/src/libnnptrain/Training.cpp
@@ -40,6 +40,7 @@ Training::Training() : Dataset(),
                        jacobianMode               (JM_SUM         ),
                        updateStrategy             (US_COMBINED    ),
                        selectionMode              (SM_RANDOM      ),
+                       decouplingType             (DT_GLOBAL      ),
                        hasUpdaters                (false          ),
                        hasStructures              (false          ),
                        useForces                  (false          ),
@@ -991,6 +992,47 @@ void Training::setupTraining()
     {
         kalmanType = (KalmanFilter::KalmanType)
                      atoi(settings["kalman_type"].c_str());
+        decouplingType = (DecouplingType)
+                         atoi(settings["decoupling_type"].c_str());
+        if (decouplingType == DT_GLOBAL)
+        {
+            log << strpr("No decoupling (GEKF) selected: DT_GLOBAL (%d).\n",
+                         decouplingType);
+        }
+        else if (decouplingType == DT_ELEMENT)
+        {
+            log << strpr("Per-element decoupling (ED-GEKF) selected: "
+                         "DT_ELEMENT (%d).\n", decouplingType);
+        }
+        else if (decouplingType == DT_LAYER)
+        {
+            log << strpr("Per-layer decoupling selected: "
+                         "DT_LAYER (%d).\n", decouplingType);
+        }
+        else if (decouplingType == DT_NODE)
+        {
+            log << strpr("Per-node decoupling (NDEKF) selected: "
+                         "DT_NODE (%d).\n", decouplingType);
+        }
+        else if (decouplingType == DT_FULL)
+        {
+            log << strpr("Full (per-weight) decoupling selected: "
+                         "DT_FULL (%d).\n", decouplingType);
+        }
+        else
+        {
+            throw runtime_error("ERROR: Unknown Kalman filter decoupling "
+                                "type.\n");
+        }
+        if (decouplingType != DT_GLOBAL &&
+            (parallelMode != PM_TRAIN_ALL || updateStrategy != US_COMBINED))
+        {
+            throw runtime_error(strpr("ERROR: Kalman filter decoupling works "
+                                      "only in conjunction with"
+                                      "\"parallel_mode %d\" and "
+                                      "\"update_strategy %d\".\n",
+                                      PM_TRAIN_ALL, US_COMBINED));
+        }
     }
 
     for (size_t i = 0; i < numUpdaters; ++i)

--- a/src/libnnptrain/Training.h
+++ b/src/libnnptrain/Training.h
@@ -110,6 +110,21 @@ public:
         SM_THRESHOLD
     };
 
+    /// Kalman filter decoupling type (requires UT_KF and US_COMBINED).
+    enum DecouplingType
+    {
+        /// No decoupling, global extended Kalman filter (GEKF).
+        DT_GLOBAL,
+        /// Per-element decoupling, ED-GEKF (doi.org/10.1021/acs.jctc.5b00211).
+        DT_ELEMENT,
+        /// Layer decoupling.
+        DT_LAYER,
+        /// Node decoupling, NDEKF.
+        DT_NODE,
+        /// Full decoupling, FDEKF.
+        DT_FULL
+    };
+
     /// Constructor.
     Training();
     /// Destructor, updater vector needs to be cleaned.
@@ -309,6 +324,8 @@ private:
     UpdateStrategy                updateStrategy;
     /// Selection mode for update candidates.
     SelectionMode                 selectionMode;
+    /// Kalman filter decoupling type if KF training selected.
+    DecouplingType                decouplingType;
     /// If this rank performs weight updates.
     bool                          hasUpdaters;
     /// If this rank holds structure information.


### PR DESCRIPTION
Implements decoupled Kalman filter (DEKF) NN training. Different levels of decoupling are possible:

* No decoupling (GEKF), limiting case of single weight group.
* Element-wise decoupling (ED-GEKF), see also https://doi.org/10.1021/acs.jctc.5b00211
* Per-layer decoupling.
* Per-node decoupling (NDEKF).
* Per-weight decoupling (full decoupling), limiting case.