### PR TITLE
Cabana: SF group initialization

### DIFF
--- a/src/libnnp/version.h
+++ b/src/libnnp/version.h
@@ -17,7 +17,7 @@
 #ifndef VERSION_H
 #define VERSION_H
 
-#define NNP_VERSION "2.0.0"
+#define NNP_VERSION "2.0.2"
 #define NNP_GIT_REV ""
 #define NNP_GIT_REV_SHORT ""
 #define NNP_GIT_BRANCH ""

--- a/src/libnnpif/CabanaMD/ElementCabana_impl.h
+++ b/src/libnnpif/CabanaMD/ElementCabana_impl.h
@@ -311,7 +311,7 @@ void ElementCabana::setupSymmetryFunctionGroups( t_SF SF,
                                                  h_t_int h_numSFGperElem,
                                                  int maxSFperElem )
 {
-    int num_group = h_numSFperElem.extent( 0 ) * 2;
+    int num_group = h_numSFperElem.extent( 0 );
     h_t_int h_numGR( "RadialCounter", num_group );
     h_t_int h_numGA( "AngularCounter", num_group );
     int SFindex;
@@ -366,12 +366,16 @@ void ElementCabana::setupSymmetryFunctionGroups( t_SF SF,
             if ( SF( attype, SFindex, 1 ) == 2 )
             {
                 SFGmemberlist( attype, l, 0 ) = SFindex;
+                if ( l >= (int)h_numGR.extent( 0 ) )
+                    Kokkos::resize( h_numGR, l+1 );
                 h_numGR( l ) = 1;
                 SFGmemberlist( attype, l, maxSFperElem )++;
             }
             else if ( SF( attype, SFindex, 1 ) == 3 )
             {
                 SFGmemberlist( attype, l, 0 ) = SFindex;
+                if ( l >= (int)h_numGA.extent( 0 ) )
+                    Kokkos::resize( h_numGA, l+1 );
                 h_numGA( l ) = 1;
                 SFGmemberlist( attype, l, maxSFperElem )++;
             }


### PR DESCRIPTION
An incorrect assumption was made about max symmetry function group sizes where it was possible to go out of bounds. The previous size assumption was sufficient for a Ni model, but not for water (although it went out of bounds I did not ever see a segfault - found using `Kokkos_ENABLE_DEBUG_BOUNDS_CHECK=ON`)