### PR TITLE
Committee-NNP

### DIFF
--- a/src/libnnp/Element.cpp
+++ b/src/libnnp/Element.cpp
@@ -308,6 +308,16 @@ void Element::setupSymmetryFunctionMemory()
     return;
 }
 
+void Element::setupCommittee(size_t const committeeSize)
+{
+    for (size_t i = 1; i <= committeeSize; ++i)
+    {
+        committeeIds.push_back(strpr("_committee-%d", i));
+    }
+
+    return;
+}
+
 vector<string> Element::infoSymmetryFunctionGroups() const
 {
     vector<string> v;

--- a/src/libnnp/Element.h
+++ b/src/libnnp/Element.h
@@ -66,6 +66,12 @@ public:
     /** Set #atomicEnergyOffset.
      */
     void                     setAtomicEnergyOffset(double atomicEnergyOffset);
+    /** Set NN ID suffixes for all committee members.
+     *
+     * @param[in] committeeIds Vector containing all committee suffixes.
+     */
+    void                     setCommitteeIds(std::vector<
+                                             std::string> committeeIds);
     /** Get #index.
      */
     std::size_t              getIndex() const;
@@ -241,6 +247,8 @@ protected:
     std::string                           symbol;
     /// Number of relevant symmetry functions for each neighbor element.
     std::vector<std::size_t>              symmetryFunctionNumTable;
+    /// ID suffixes of neural network committee members.
+    std::vector<std::string>              committeeIds;
     /// List of symmetry function indices relevant for each neighbor element.
     std::vector<std::vector<std::size_t>> symmetryFunctionTable;
 #ifndef N2P2_NO_SF_CACHE
@@ -260,6 +268,13 @@ protected:
 inline void Element::setAtomicEnergyOffset(double atomicEnergyOffset)
 {
     this->atomicEnergyOffset = atomicEnergyOffset;
+
+    return;
+}
+
+inline void Element::setCommitteeIds(std::vector<std::string> committeeIds)
+{
+    this->committeeIds = committeeIds;
 
     return;
 }

--- a/src/libnnp/Mode.h
+++ b/src/libnnp/Mode.h
@@ -90,6 +90,17 @@ public:
         SHORT_CHARGE_NN
     };
 
+    /// Describes how multiple NNs in a committee should be used.
+    enum class CommitteeMode
+    {
+        /// No committee functionality used, only single NN prediction.
+        DISABLED,
+        /// Only a single NN predicts, all toghether are used for validation.
+        VALIDATION,
+        /// All committee NNs are averaged for predicition.
+        PREDICTION
+    };
+
     Mode();
     /** Write welcome message with version information.
      */
@@ -502,11 +513,15 @@ public:
 
 protected:
     NNPType                    nnpType;
+    CommitteeMode              committeeMode;
     bool                       normalize;
     bool                       checkExtrapolationWarnings;
     bool                       useChargeNN;
     std::size_t                numElements;
+    std::size_t                committeeSize;
+    std::string                committeePrefix;
     std::vector<std::size_t>   minNeighbors;
+    std::vector<std::string>   committeeIds;
     std::vector<double>        minCutoffRadius;
     double                     maxCutoffRadius;
     double                     cutoffAlpha;

--- a/src/libnnp/Settings.cpp
+++ b/src/libnnp/Settings.cpp
@@ -52,6 +52,8 @@ map<string, shared_ptr<Settings::Key>> const createKnownKeywordsMap()
     m["conv_length"                   ] = "";
     m["conv_energy"                   ] = "";
     m["nnp_type"                      ] = "";
+    m["committee_mode"                ] = "";
+    m["committee_dir_prefix"          ] = "";
 
     // Training keywords.
     m["random_seed"                   ] = "";


### PR DESCRIPTION
Implement committee NNPs (C-NNPs) as presented in  [J. Chem. Phys. 153, 104105 (2020)](http://dx.doi.org/10.1063/5.0016004) in the core library, applications (only prediction, no training) and LAMMPS interface.

Allow two different modes in LAMMPS (and tools where useful):

1. **Validation**: committee is used to estimate the error, but only a single NN drives the MD.
2. **Prediction**: use committee average in MD simulation (actual method in above publication).

New keywords introduced:

* `committee_mode`, arguments can be `validation` or `prediction`
* `committee_dir_prefix`, two arguments:
   1. prefix for committee member data directories.
   2. number of committee members.