### PR TITLE
Allow overriding make

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -43,9 +43,9 @@ INTERFACES=LAMMPS CabanaMD
 # APPLICATION TARGET NAMES
 ###############################################################################
 # Call makefile in "application" directory to list targets.
-APP_CORE=$(shell cd application && make list-core)
-APP_TRAIN=$(shell cd application && make list-train)
-APP=$(shell cd application && make list-all)
+APP_CORE=$(shell cd application && $(MAKE) $(MFLAGS) list-core)
+APP_TRAIN=$(shell cd application && $(MAKE) $(MFLAGS) list-train)
+APP=$(shell cd application && $(MAKE) $(MFLAGS) list-all)
 
 # Targets for cleaning.
 CLEAN_APP=$(patsubst %, clean-%, $(APP))


### PR DESCRIPTION
This improves portability to systems where the default "make" program is **not** GNU make and thus one needs to override it, e.g. with `gmake`.

Fixes #114 