### PR TITLE
Work around MPI compilation failures when cross-compiling LAMMPS to Windows

### DIFF
--- a/src/libnnpif/LAMMPS/InterfaceLammps.cpp
+++ b/src/libnnpif/LAMMPS/InterfaceLammps.cpp
@@ -494,23 +494,23 @@ void InterfaceLammps::fillEWBuffer(char* const& buf, int bs) const
         map<size_t, SymFncStatistics::Container> const& m =
             it->statistics.data;
         size_t n = m.size();
-        MPI_Pack(&(n), 1, MPI_SIZE_T, buf, bs, &p, MPI_COMM_WORLD);
+        MPI_Pack((void *) &(n), 1, MPI_SIZE_T, buf, bs, &p, MPI_COMM_WORLD);
         for (map<size_t, SymFncStatistics::Container>::const_iterator
              it2 = m.begin(); it2 != m.end(); ++it2)
         {
-            MPI_Pack(&(it2->first                          ),       1, MPI_SIZE_T, buf, bs, &p, MPI_COMM_WORLD);
+            MPI_Pack((void *) &(it2->first                          ),       1, MPI_SIZE_T, buf, bs, &p, MPI_COMM_WORLD);
             size_t countEW = it2->second.countEW;
-            MPI_Pack(&(countEW                             ),       1, MPI_SIZE_T, buf, bs, &p, MPI_COMM_WORLD);
-            MPI_Pack(&(it2->second.type                    ),       1, MPI_SIZE_T, buf, bs, &p, MPI_COMM_WORLD);
-            MPI_Pack(&(it2->second.Gmin                    ),       1, MPI_DOUBLE, buf, bs, &p, MPI_COMM_WORLD);
-            MPI_Pack(&(it2->second.Gmax                    ),       1, MPI_DOUBLE, buf, bs, &p, MPI_COMM_WORLD);
+            MPI_Pack((void *) &(countEW                             ),       1, MPI_SIZE_T, buf, bs, &p, MPI_COMM_WORLD);
+            MPI_Pack((void *) &(it2->second.type                    ),       1, MPI_SIZE_T, buf, bs, &p, MPI_COMM_WORLD);
+            MPI_Pack((void *) &(it2->second.Gmin                    ),       1, MPI_DOUBLE, buf, bs, &p, MPI_COMM_WORLD);
+            MPI_Pack((void *) &(it2->second.Gmax                    ),       1, MPI_DOUBLE, buf, bs, &p, MPI_COMM_WORLD);
             // it2->element
             size_t ts = it2->second.element.length() + 1;
-            MPI_Pack(&ts                                    ,       1, MPI_SIZE_T, buf, bs, &p, MPI_COMM_WORLD);
-            MPI_Pack(it2->second.element.c_str()            ,      ts, MPI_CHAR  , buf, bs, &p, MPI_COMM_WORLD);
-            MPI_Pack(&(it2->second.indexStructureEW.front()), countEW, MPI_SIZE_T, buf, bs, &p, MPI_COMM_WORLD);
-            MPI_Pack(&(it2->second.indexAtomEW.front()     ), countEW, MPI_SIZE_T, buf, bs, &p, MPI_COMM_WORLD);
-            MPI_Pack(&(it2->second.valueEW.front()         ), countEW, MPI_DOUBLE, buf, bs, &p, MPI_COMM_WORLD);
+            MPI_Pack((void *) &ts                                    ,       1, MPI_SIZE_T, buf, bs, &p, MPI_COMM_WORLD);
+            MPI_Pack((void *) it2->second.element.c_str()            ,      ts, MPI_CHAR  , buf, bs, &p, MPI_COMM_WORLD);
+            MPI_Pack((void *) &(it2->second.indexStructureEW.front()), countEW, MPI_SIZE_T, buf, bs, &p, MPI_COMM_WORLD);
+            MPI_Pack((void *) &(it2->second.indexAtomEW.front()     ), countEW, MPI_SIZE_T, buf, bs, &p, MPI_COMM_WORLD);
+            MPI_Pack((void *) &(it2->second.valueEW.front()         ), countEW, MPI_DOUBLE, buf, bs, &p, MPI_COMM_WORLD);
         }
     }
 #endif
@@ -525,33 +525,33 @@ void InterfaceLammps::extractEWBuffer(char const* const& buf, int bs)
          it != elements.end(); ++it)
     {
         size_t n = 0;
-        MPI_Unpack(buf, bs, &p, &(n), 1, MPI_SIZE_T, MPI_COMM_WORLD);
+        MPI_Unpack((void *) buf, bs, &p, &(n), 1, MPI_SIZE_T, MPI_COMM_WORLD);
         for (size_t i = 0; i < n; ++i)
         {
             size_t index = 0;
-            MPI_Unpack(buf, bs, &p, &(index), 1, MPI_SIZE_T, MPI_COMM_WORLD);
+            MPI_Unpack((void *) buf, bs, &p, &(index), 1, MPI_SIZE_T, MPI_COMM_WORLD);
             SymFncStatistics::Container& d = it->statistics.data[index];
             size_t countEW = 0;
-            MPI_Unpack(buf, bs, &p, &(countEW                      ),       1, MPI_SIZE_T, MPI_COMM_WORLD);
-            MPI_Unpack(buf, bs, &p, &(d.type                       ),       1, MPI_SIZE_T, MPI_COMM_WORLD);
-            MPI_Unpack(buf, bs, &p, &(d.Gmin                       ),       1, MPI_DOUBLE, MPI_COMM_WORLD);
-            MPI_Unpack(buf, bs, &p, &(d.Gmax                       ),       1, MPI_DOUBLE, MPI_COMM_WORLD);
+            MPI_Unpack((void *) buf, bs, &p, &(countEW                      ),       1, MPI_SIZE_T, MPI_COMM_WORLD);
+            MPI_Unpack((void *) buf, bs, &p, &(d.type                       ),       1, MPI_SIZE_T, MPI_COMM_WORLD);
+            MPI_Unpack((void *) buf, bs, &p, &(d.Gmin                       ),       1, MPI_DOUBLE, MPI_COMM_WORLD);
+            MPI_Unpack((void *) buf, bs, &p, &(d.Gmax                       ),       1, MPI_DOUBLE, MPI_COMM_WORLD);
             // d.element
             size_t ts = 0;
-            MPI_Unpack(buf, bs, &p, &ts                             ,       1, MPI_SIZE_T, MPI_COMM_WORLD);
+            MPI_Unpack((void *) buf, bs, &p, &ts                             ,       1, MPI_SIZE_T, MPI_COMM_WORLD);
             char* element = new char[ts];
-            MPI_Unpack(buf, bs, &p, element                         ,      ts, MPI_CHAR  , MPI_COMM_WORLD);
+            MPI_Unpack((void *) buf, bs, &p, element                         ,      ts, MPI_CHAR  , MPI_COMM_WORLD);
             d.element = element;
             delete[] element;
             // indexStructureEW.
             d.indexStructureEW.resize(d.countEW + countEW);
-            MPI_Unpack(buf, bs, &p, &(d.indexStructureEW[d.countEW]), countEW, MPI_SIZE_T, MPI_COMM_WORLD);
+            MPI_Unpack((void *) buf, bs, &p, &(d.indexStructureEW[d.countEW]), countEW, MPI_SIZE_T, MPI_COMM_WORLD);
             // indexAtomEW.
             d.indexAtomEW.resize(d.countEW + countEW);
-            MPI_Unpack(buf, bs, &p, &(d.indexAtomEW[d.countEW]     ), countEW, MPI_SIZE_T, MPI_COMM_WORLD);
+            MPI_Unpack((void *) buf, bs, &p, &(d.indexAtomEW[d.countEW]     ), countEW, MPI_SIZE_T, MPI_COMM_WORLD);
             // valueEW.
             d.valueEW.resize(d.countEW + countEW);
-            MPI_Unpack(buf, bs, &p, &(d.valueEW[d.countEW]         ), countEW, MPI_DOUBLE, MPI_COMM_WORLD);
+            MPI_Unpack((void *) buf, bs, &p, &(d.valueEW[d.countEW]         ), countEW, MPI_DOUBLE, MPI_COMM_WORLD);
 
             d.countEW += countEW;
         }


### PR DESCRIPTION
This change casts MPI_Pack()/MPI_Unpack() argument pointers to `void *` to work around compilation failures with mingw64 cross compilers on Linux. We're currently working around this with running `sed` on the source file before compiling.