### PR TITLE
[WIP] Implement additional structure and force weights in the loss function

### DIFF
--- a/src/libnnp/Atom.cpp
+++ b/src/libnnp/Atom.cpp
@@ -37,7 +37,8 @@ Atom::Atom() : hasNeighborList               (false),
                numSymmetryFunctions          (0    ),
                energy                        (0.0  ),
                charge                        (0.0  ),
-               chargeRef                     (0.0  )
+               chargeRef                     (0.0  ),
+               forceWeight                   (1.0  )
 {
 }
 
@@ -363,6 +364,7 @@ vector<string> Atom::info() const
     v.push_back(strpr("energy                         : %16.8E\n", energy));
     v.push_back(strpr("charge                         : %16.8E\n", charge));
     v.push_back(strpr("chargeRef                      : %16.8E\n", chargeRef));
+    v.push_back(strpr("forceWeight                    : %16.8E\n", forceWeight));
     v.push_back(strpr("r                              : %16.8E %16.8E %16.8E\n", r[0], r[1], r[2]));
     v.push_back(strpr("f                              : %16.8E %16.8E %16.8E\n", f[0], f[1], f[2]));
     v.push_back(strpr("fRef                           : %16.8E %16.8E %16.8E\n", fRef[0], fRef[1], fRef[2]));

--- a/src/libnnp/Atom.h
+++ b/src/libnnp/Atom.h
@@ -114,6 +114,8 @@ struct Atom
     double                   charge;
     /// Atomic reference charge.
     double                   chargeRef;
+    /// Force weight for training.
+    double                   forceWeight;
     /// Cartesian coordinates
     Vec3D                    r;
     /// Force vector calculated by neural network.

--- a/src/libnnp/Structure.cpp
+++ b/src/libnnp/Structure.cpp
@@ -42,6 +42,7 @@ Structure::Structure() :
     charge                        (0.0       ),
     chargeRef                     (0.0       ),
     volume                        (0.0       ),
+    strucWeight                   (1.0       ),
     sampleType                    (ST_UNKNOWN),
     comment                       (""        )
 {
@@ -206,6 +207,10 @@ void Structure::readFromLines(vector<string> const& lines)
             atoms.back().r[2]           = atof(splitLine.at(3).c_str());
             atoms.back().element        = elementMap[splitLine.at(4)];
             atoms.back().chargeRef      = atof(splitLine.at(5).c_str());
+            atoms.back().forceWeight    = atof(splitLine.at(6).c_str());
+            if (atoms.back().forceWeight == 0) {
+                atoms.back().forceWeight = 1.0;
+            }
             atoms.back().fRef[0]        = atof(splitLine.at(7).c_str());
             atoms.back().fRef[1]        = atof(splitLine.at(8).c_str());
             atoms.back().fRef[2]        = atof(splitLine.at(9).c_str());
@@ -220,6 +225,10 @@ void Structure::readFromLines(vector<string> const& lines)
         else if (splitLine.at(0) == "charge")
         {
             chargeRef = atof(splitLine[1].c_str());
+        }
+        else if (splitLine.at(0) == "weight")
+        {
+            strucWeight = atof(splitLine[1].c_str());
         }
         else if (splitLine.at(0) == "end")
         {
@@ -555,6 +564,7 @@ void Structure::reset()
     charge                         = 0.0       ;
     chargeRef                      = 0.0       ;
     volume                         = 0.0       ;
+    strucWeight                    = 1.0       ;
     sampleType                     = ST_UNKNOWN;
     comment                        = ""        ;
 

--- a/src/libnnp/Structure.h
+++ b/src/libnnp/Structure.h
@@ -82,6 +82,8 @@ struct Structure
     double                   chargeRef;
     /// Simulation box volume.
     double                   volume;
+    /// Structure weight
+    double                   strucWeight;
     /// Sample type (training or test set).
     SampleType               sampleType;
     /// Structure comment.

--- a/src/libnnptrain/Dataset.cpp
+++ b/src/libnnptrain/Dataset.cpp
@@ -179,7 +179,7 @@ int Dataset::calculateBufferSize(Structure const& structure) const
     MPI_Pack_size(1, MPI_CHAR   , comm, &cs  );
 
     // Structure
-    bs += 5 * cs + 4 * ss + 4 * is + 5 * ds;
+    bs += 5 * cs + 4 * ss + 4 * is + 6 * ds;
     // Structure.comment
     bs += ss;
     bs += (s.comment.length() + 1) * cs;
@@ -192,7 +192,7 @@ int Dataset::calculateBufferSize(Structure const& structure) const
     bs += s.numAtomsPerElement.size() * ss;
     // Structure.atoms
     bs += ss;
-    bs += s.atoms.size() * (4 * cs + 6 * ss + i64s + 3 * ds + 3 * 3 * ds);
+    bs += s.atoms.size() * (4 * cs + 6 * ss + i64s + 4 * ds + 3 * 3 * ds);
     for (vector<Atom>::const_iterator it = s.atoms.begin();
          it != s.atoms.end(); ++it)
     {
@@ -275,6 +275,7 @@ int Dataset::sendStructure(Structure const& structure, int dest) const
     MPI_Pack(&(s.charge                        ), 1, MPI_DOUBLE, buf, bs, &p, comm);
     MPI_Pack(&(s.chargeRef                     ), 1, MPI_DOUBLE, buf, bs, &p, comm);
     MPI_Pack(&(s.volume                        ), 1, MPI_DOUBLE, buf, bs, &p, comm);
+    MPI_Pack(&(s.strucWeight                   ), 1, MPI_DOUBLE, buf, bs, &p, comm);
     MPI_Pack(&(s.sampleType                    ), 1, MPI_INT   , buf, bs, &p, comm);
 
     // Strucuture.comment
@@ -325,6 +326,7 @@ int Dataset::sendStructure(Structure const& structure, int dest) const
             MPI_Pack(&(it->energy                        ), 1, MPI_DOUBLE , buf, bs, &p, comm);
             MPI_Pack(&(it->charge                        ), 1, MPI_DOUBLE , buf, bs, &p, comm);
             MPI_Pack(&(it->chargeRef                     ), 1, MPI_DOUBLE , buf, bs, &p, comm);
+            MPI_Pack(&(it->forceWeight                   ), 1, MPI_DOUBLE , buf, bs, &p, comm);
             MPI_Pack(&(it->r.r                           ), 3, MPI_DOUBLE , buf, bs, &p, comm);
             MPI_Pack(&(it->f.r                           ), 3, MPI_DOUBLE , buf, bs, &p, comm);
             MPI_Pack(&(it->fRef.r                        ), 3, MPI_DOUBLE , buf, bs, &p, comm);
@@ -492,6 +494,7 @@ int Dataset::recvStructure(Structure* const structure, int src)
     MPI_Unpack(buf, bs, &p, &(s->charge                        ), 1, MPI_DOUBLE, comm);
     MPI_Unpack(buf, bs, &p, &(s->chargeRef                     ), 1, MPI_DOUBLE, comm);
     MPI_Unpack(buf, bs, &p, &(s->volume                        ), 1, MPI_DOUBLE, comm);
+    MPI_Unpack(buf, bs, &p, &(s->strucWeight                   ), 1, MPI_DOUBLE, comm);
     MPI_Unpack(buf, bs, &p, &(s->sampleType                    ), 1, MPI_INT   , comm);
 
     // Strucuture.comment
@@ -549,6 +552,7 @@ int Dataset::recvStructure(Structure* const structure, int src)
             MPI_Unpack(buf, bs, &p, &(it->energy                        ), 1, MPI_DOUBLE , comm);
             MPI_Unpack(buf, bs, &p, &(it->charge                        ), 1, MPI_DOUBLE , comm);
             MPI_Unpack(buf, bs, &p, &(it->chargeRef                     ), 1, MPI_DOUBLE , comm);
+            MPI_Unpack(buf, bs, &p, &(it->forceWeight                   ), 1, MPI_DOUBLE , comm);
             MPI_Unpack(buf, bs, &p, &(it->r.r                           ), 3, MPI_DOUBLE , comm);
             MPI_Unpack(buf, bs, &p, &(it->f.r                           ), 3, MPI_DOUBLE , comm);
             MPI_Unpack(buf, bs, &p, &(it->fRef.r                        ), 3, MPI_DOUBLE , comm);

--- a/src/libnnptrain/Training.cpp
+++ b/src/libnnptrain/Training.cpp
@@ -2451,12 +2451,12 @@ void Training::update(string const& property)
         {
             if (k == "energy")
             {
-                pu.error.at(0).at(offset2) += s.energyRef - s.energy;
+                pu.error.at(0).at(offset2) += (s.energyRef - s.energy) * s.strucWeight;
             }
             else if (k == "force")
             {
                 Atom const& a = s.atoms.at(c->a);
-                pu.error.at(0).at(offset2) +=  a.fRef[c->c] - a.f[c->c];
+                pu.error.at(0).at(offset2) +=  (a.fRef[c->c] - a.f[c->c]) * s.strucWeight * a.forceWeight;
             }
             else if (k == "charge")
             {


### PR DESCRIPTION
This PR implements two additional weights to be considered in the loss function of NNP optimizations.

Configurations can be weighted with a new keyword `weight` in the input.data file as proposed in #91. 
Individual atomic force components can be weighted via the unused 6th column of the `atom` keyword in input.data.

The PR works as expected, but there are two aspects that require discussion:
1. In order to restore default behavior for existing data sets, atomic force weights of 0 are converted to 1.
2. Weights are only applied on the error and not in the Jacobian, as the latter one introduced deteriorating quality.

Resolves #91, resolves #121. 